### PR TITLE
Fix @import Direktive für SCSS Dateien

### DIFF
--- a/lib/res42min.php
+++ b/lib/res42min.php
@@ -204,6 +204,7 @@ class res42min extends res42 {
 
                               $scss = new scssc();
                               $scss->setFormatter($formatter);
+                              $scss->addImportPath($path['dirname']);
 
                               $compiledCSS = $scss->compile($sourceFileContent);
                         }


### PR DESCRIPTION
SCSS Import Path setzen damit SCSS-Dateien via @import korrekt in die
resultierende Datei eingebettet werden.